### PR TITLE
Fixes deploy function error

### DIFF
--- a/mememachine.yml
+++ b/mememachine.yml
@@ -1,5 +1,5 @@
 provider:
-  name: faas
+  name: openfaas
   gateway: http://localhost:8080
 
 functions:


### PR DESCRIPTION
Not it has an error with this message:
```
['openfaas'] is the only valid "provider.name" for the OpenFaaS CLI, but you gave: faas
```